### PR TITLE
Two small bug fixes

### DIFF
--- a/Sources/LLVS/Core/Value.swift
+++ b/Sources/LLVS/Core/Value.swift
@@ -28,7 +28,7 @@ public struct Value: Codable, Identifiable {
     }
     
     /// Convenience that saves creating IDs
-    public init(idString: String = UUID().uuidString, data: Data) {
+    public init(idString: String, data: Data) {
         self.init(id: ID(idString), data: data)
     }
     

--- a/Sources/LLVS/Exchanges/FileSystemExchange.swift
+++ b/Sources/LLVS/Exchanges/FileSystemExchange.swift
@@ -43,7 +43,7 @@ public class FileSystemExchange: NSObject, Exchange, NSFilePresenter {
     fileprivate let fileManager = FileManager()
     fileprivate let queue = OperationQueue()
 
-    init(rootDirectoryURL: URL, store: Store, usesFileCoordination: Bool) {
+    public init(rootDirectoryURL: URL, store: Store, usesFileCoordination: Bool) {
         self.rootDirectoryURL = rootDirectoryURL
         self.store = store
         self.usesFileCoordination = usesFileCoordination


### PR DESCRIPTION
While testing the (great) idea, I came across two code mistakes:

1- `FileSystemExchange` init is not marked as `public`, making it impossible to use outside the LLVS package

2- The two inits in`Value` has a different first argument but has the same second argument, so when trying to use it with only the second value, the compiler gives the error `Ambiguous use of 'init'`. Since the two default values are doing the same (creating a UUID), I removed the default value from one of them.